### PR TITLE
[V2PROD-641] Accept multiple different types of webhooks 

### DIFF
--- a/lib/mongo-interface.ts
+++ b/lib/mongo-interface.ts
@@ -1,5 +1,12 @@
 import { Mongoose, Schema } from 'mongoose'
 
+export interface WebhookError {
+  requestInput: any,
+  errorMessage:any,
+  createdAt: number,
+  type:string
+}
+
 export interface WebhookReceipt {
   requestId: string
   user: any
@@ -13,8 +20,17 @@ export interface WebhookReceipt {
 export default class MongoInterface {
   mongoose = new Mongoose()
 
+
+  WebhookErrorSchema = new Schema<WebhookError>({
+    requestInput: Object,
+    errorMessage: Object,
+    createdAt: Number,
+    type: String
+  })
+
+
   WebhookReceiptSchema = new Schema<WebhookReceipt>({
-    requestId: { type: String, index: true, unique: true },
+    requestId: { type: String, index: true, unique: true, required: true},
     user: Object,
     template: Object,
     profile: Object,
@@ -27,6 +43,13 @@ export default class MongoInterface {
     'webhookreceipts',
     this.WebhookReceiptSchema
   )
+
+
+  WebhookErrorModel = this.mongoose.model<WebhookError>(
+    'webhookerrors',
+    this.WebhookErrorSchema
+  )
+
 
   async init(dbName: string, config?: any): Promise<void> {
     const host: string = config?.url ?? 'localhost'

--- a/lib/mongo-interface.ts
+++ b/lib/mongo-interface.ts
@@ -6,7 +6,8 @@ export interface WebhookReceipt {
   template: any
   profile: any
   application: any
-  createdAt: number
+  createdAt: number,
+  type:string
 }
 
 export default class MongoInterface {
@@ -19,6 +20,7 @@ export default class MongoInterface {
     profile: Object,
     application: Object,
     createdAt: Number,
+    type: String
   })
 
   WebhookReceiptModel = this.mongoose.model<WebhookReceipt>(

--- a/server/config/routes.json
+++ b/server/config/routes.json
@@ -1,7 +1,14 @@
 [
     {"type":"get","uri":"/api/ping","method":"ping","controller":"api"},
  
-    {"type":"post","uri":"/api/webhook","method":"receiveWebhook","controller":"api"} 
+    
+    {"type":"post","uri":"/api/bnpl-kyc/webhook","method":"receiveBNPLKYC","controller":"api"},
+    {"type":"post","uri":"/api/bnpl-lender/webhook","method":"receiveBNPLLender","controller":"api"},
+    {"type":"post","uri":"/api/mortgage-borrower/webhook","method":"receiveMortgageBorrower","controller":"api"} ,
+    {"type":"post","uri":"/api/mortgage-lender/webhook","method":"receiveMortgageLender","controller":"api"} 
+   
+  
+   
   
    
 ]

--- a/server/config/routes.json
+++ b/server/config/routes.json
@@ -1,7 +1,7 @@
 [
     {"type":"get","uri":"/api/ping","method":"ping","controller":"api"},
  
-    
+    {"type":"post","uri":"/api/webhook","method":"receiveBNPLKYC","controller":"api"},
     {"type":"post","uri":"/api/bnpl-kyc/webhook","method":"receiveBNPLKYC","controller":"api"},
     {"type":"post","uri":"/api/bnpl-lender/webhook","method":"receiveBNPLLender","controller":"api"},
     {"type":"post","uri":"/api/mortgage-borrower/webhook","method":"receiveMortgageBorrower","controller":"api"} ,

--- a/server/controllers/api-controller.ts
+++ b/server/controllers/api-controller.ts
@@ -6,6 +6,9 @@ import MongoInterface, { WebhookReceipt } from '../../lib/mongo-interface'
 
 const crypto = require('crypto')
 
+const shouldSendEmail = AppHelper.getEnvironmentName() == 'production'
+
+
 export default class ApiController {
   constructor(public mongoInterface: MongoInterface) {}
 
@@ -17,72 +20,210 @@ export default class ApiController {
     @notice Accepts a webhook call from Bloom API 
  
   */
-  receiveWebhook: APICall = async (req: any, res: any) => {
-    const inputParams = req.body
 
-    const signature = req.headers['x-onramp-signature']
+    verifyHmacSignature( req: any ){
 
-    const expectedSignature = crypto
-      .createHmac('sha256', process.env.ONRAMP_WEBHOOK_KEY)
-      .update(req.rawBody)
-      .digest('base64')
+ 
+      const signature = req.headers['x-onramp-signature']
 
-    if (signature !== expectedSignature) {
-      return res.status(401).send({
-        success: false,
-        error: 'invalid signature',
-      })
-    }
-
-
-    if(!inputParams.requestId){
-      return res.status(200).send({
-        success: false, error:'missing request id'
-      })
-    }
-
-
-    const receipt: WebhookReceipt = {
-      requestId: inputParams.requestId,
-      user: inputParams.user,
-      template: inputParams.template,
-      profile: inputParams.profile,
-      application: inputParams.application,
-      createdAt: Date.now(),
-    }
-
+      const expectedSignature = crypto
+        .createHmac('sha256', process.env.ONRAMP_WEBHOOK_KEY)
+        .update(req.rawBody)
+        .digest('base64')
   
-
-    let createdRecord
-    let sentEmail
-
-    try {
-      createdRecord = await this.mongoInterface.WebhookReceiptModel.create(
-        receipt
-      )
-
-      console.log('inserted', createdRecord)
-    } catch (error) {
-      console.error(error)
-    }
-
-    try {
-      const shouldSendEmail = AppHelper.getEnvironmentName() == 'production'
-
-      if (shouldSendEmail) {
-        sentEmail = await sendEmail(
-          'Bloom API Alert',
-          `A webhook has been received with request_id: ${inputParams.requestId}`
-        )
-
-        console.log('sent email', sentEmail)
+      if (signature !== expectedSignature) {
+        return  {
+          success: false,
+          error: 'invalid signature',
+        }
       }
-    } catch (error) {
-      console.error(error)
+
+
+      return {success:true}
+
     }
 
-    return res.status(200).send({
-      success: true,
-    })
-  }
+
+
+    async storeAndBroadcastReceipt(receipt:WebhookReceipt){
+
+      let createdRecord
+      let sentEmail
+  
+      try {
+        createdRecord = await this.mongoInterface.WebhookReceiptModel.create(
+          receipt
+        )
+   
+      } catch (error) {
+        console.error(error)
+      }
+  
+      try {
+        
+  
+        if (shouldSendEmail) {
+          sentEmail = await sendEmail(
+            'Bloom API Alert',
+            `A ${receipt.type} webhook has been received with request_id: ${receipt.requestId}`
+          )
+  
+          console.log('sent email', sentEmail)
+        }
+      } catch (error) {
+        console.error(error)
+      }
+
+
+      return {createdRecord, sentEmail}
+
+    }
+
+
+    receiveBNPLKYC: APICall = async (req: any, res: any) => {
+      const inputParams = req.body
+
+      let verifySignatureResult = this.verifyHmacSignature(req)
+
+      if(!verifySignatureResult.success){
+        return res.status(401).send(verifySignatureResult)
+      }
+
+
+      if(!inputParams.requestId){
+        return res.status(200).send({
+          success: false, error:'missing request id'
+        })
+      }
+
+
+      const receipt: WebhookReceipt = {
+        requestId: inputParams.requestId,
+        user: inputParams.user,
+        template: inputParams.template,
+        profile: inputParams.profile,
+        application: inputParams.application,
+        createdAt: Date.now(),
+        type:'BNPL_KYC'
+      }
+      
+      let {createdRecord, sentEmail} = await this.storeAndBroadcastReceipt(receipt)
+
+      
+      return res.status(200).send({
+        success: true,
+      })
+    }
+
+
+
+    receiveBNPLLender: APICall = async (req: any, res: any) => {
+      const inputParams = req.body
+
+      let verifySignatureResult = this.verifyHmacSignature(req)
+
+      if(!verifySignatureResult.success){
+        return res.status(401).send(verifySignatureResult)
+      }
+
+
+      if(!inputParams.requestId){
+        return res.status(200).send({
+          success: false, error:'missing request id'
+        })
+      }
+
+
+      const receipt: WebhookReceipt = {
+        requestId: inputParams.requestId,
+        user: inputParams.user,
+        template: inputParams.template,
+        profile: inputParams.profile,
+        application: inputParams.application,
+        createdAt: Date.now(),
+        type:'BNPL_Lender'
+      }
+      
+      let {createdRecord, sentEmail} = await this.storeAndBroadcastReceipt(receipt)
+
+      
+      return res.status(200).send({
+        success: true,
+      })
+    }
+
+
+    receiveMortgageBorrower: APICall = async (req: any, res: any) => {
+      const inputParams = req.body
+
+      let verifySignatureResult = this.verifyHmacSignature(req)
+
+      if(!verifySignatureResult.success){
+        return res.status(401).send(verifySignatureResult)
+      }
+
+
+      if(!inputParams.requestId){
+        return res.status(200).send({
+          success: false, error:'missing request id'
+        })
+      }
+
+
+      const receipt: WebhookReceipt = {
+        requestId: inputParams.requestId,
+        user: inputParams.user,
+        template: inputParams.template,
+        profile: inputParams.profile,
+        application: inputParams.application,
+        createdAt: Date.now(),
+        type:'Mortgage_Borrower'
+      }
+      
+      let {createdRecord, sentEmail} = await this.storeAndBroadcastReceipt(receipt)
+
+      
+      return res.status(200).send({
+        success: true,
+      })
+    }
+
+
+    receiveMortgageLender: APICall = async (req: any, res: any) => {
+      const inputParams = req.body
+
+      let verifySignatureResult = this.verifyHmacSignature(req)
+
+      if(!verifySignatureResult.success){
+        return res.status(401).send(verifySignatureResult)
+      }
+
+
+      if(!inputParams.requestId){
+        return res.status(200).send({
+          success: false, error:'missing request id'
+        })
+      }
+
+
+      const receipt: WebhookReceipt = {
+        requestId: inputParams.requestId,
+        user: inputParams.user,
+        template: inputParams.template,
+        profile: inputParams.profile,
+        application: inputParams.application,
+        createdAt: Date.now(),
+        type:'Mortgage_Lender'
+      }
+      
+      let {createdRecord, sentEmail} = await this.storeAndBroadcastReceipt(receipt)
+
+      
+      return res.status(200).send({
+        success: true,
+      })
+    }
+
+
+    
 }

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -46,8 +46,8 @@ describe('Webhook Server', () => {
         },
       }
 
-      const result = axios
-        .post(uriRoot + '/api/webhook', inputParams, headers)
+      const result = await axios
+        .post(uriRoot + '/api/bnpl-kyc/webhook', inputParams, headers)
         .then((res) => {
           throw new Error('webhook was supposed to fail')
         })
@@ -74,7 +74,7 @@ describe('Webhook Server', () => {
       }
 
       const result = await axios.post(
-        uriRoot + '/api/webhook',
+        uriRoot + '/api/bnpl-kyc/webhook',
         inputParams,
         headers
       )

--- a/test/server.spec.ts
+++ b/test/server.spec.ts
@@ -59,6 +59,14 @@ describe('Webhook Server', () => {
         .catch((err) => {
           expect(err.response.status).to.eql(401)
         })
+
+
+        let loggedError: any = await webServer.mongoInterface.WebhookErrorModel.findOne({}).sort({createdAt: -1})
+
+
+        console.log('loggedError',loggedError)
+  
+        expect(loggedError.errorMessage).to.eql('Invalid HMAC signature')
     })
 
     it('should accept a webhook', async () => {


### PR DESCRIPTION
Instead of only 1 type of webhook, there are now 4 types as follows: 

 {"type":"post","uri":"/api/bnpl-kyc/webhook","method":"receiveBNPLKYC","controller":"api"},
    {"type":"post","uri":"/api/bnpl-lender/webhook","method":"receiveBNPLLender","controller":"api"},
    {"type":"post","uri":"/api/mortgage-borrower/webhook","method":"receiveMortgageBorrower","controller":"api"} ,
    {"type":"post","uri":"/api/mortgage-lender/webhook","method":"receiveMortgageLender","controller":"api"} 